### PR TITLE
Add support for independently building source and tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@vamship/build-utils",
-    "version": "1.4.4",
+    "version": "1.5.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@vamship/build-utils",
-            "version": "1.4.4",
+            "version": "1.5.0",
             "license": "MIT",
             "dependencies": {
                 "camelcase": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vamship/build-utils",
-    "version": "1.4.4",
+    "version": "1.5.0",
     "description": "Utility library for build tooling",
     "main": "src/index.js",
     "scripts": {

--- a/src/task-builders/build/build-js-impl.js
+++ b/src/task-builders/build/build-js-impl.js
@@ -51,12 +51,12 @@ module.exports = (project, options) => {
             .src(paths, { allowEmpty: true, base: rootDir.globPath })
             .pipe(_gulp.dest(workingDir.absolutePath));
 
-    task.displayName = 'build-js';
+    task.displayName = 'build-js-impl';
     task.description = 'Copy javascript files from source to build directory';
 
     if (watch) {
         const watchTask = () => _gulp.watch(paths, task);
-        watchTask.displayName = 'watch-build-js';
+        watchTask.displayName = 'watch-build-js-impl';
         watchTask.description =
             'Automatically copy javascript files to build directory on change';
 

--- a/src/task-builders/build/build-js-impl.js
+++ b/src/task-builders/build/build-js-impl.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const _gulp = require('gulp');
+
+/**
+ * Sub builder that creates a task that will copy javascript files from source
+ * to build directories. This method will return a watcher if the watch option
+ * is set to true.
+ *
+ * @private
+ * @param {Object} project Reference to an object that contains project metadata
+ *        that can be used to customize build outputs.
+ * @param {Object} options An options object that can be used to customize the
+ *        task.
+ *
+ * @returns {Function} A gulp task.
+ */
+module.exports = (project, options) => {
+    const { watch } = Object.assign({ watch: false }, options);
+    const rootDir = project.rootDir;
+    const workingDir = rootDir.getChild('working');
+
+    const dirs = ['src'];
+    if (project.projectType === 'aws-microservice') {
+        dirs.push('infra');
+    }
+
+    const extras = [
+        project.configFileName,
+        'package.json',
+        '.npmignore',
+        '.npmrc',
+    ];
+
+    if (project.hasDocker) {
+        extras.push('Dockerfile*');
+    }
+
+    const staticFilePatterns = ['js', 'json'].concat(
+        project.staticFilePatterns
+    );
+
+    const paths = dirs
+        .map((dir) => rootDir.getChild(dir))
+        .map((dir) => staticFilePatterns.map((ext) => dir.getAllFilesGlob(ext)))
+        .reduce((result, arr) => result.concat(arr), [])
+        .concat(extras.map((item) => rootDir.getFileGlob(item)));
+
+    const task = () =>
+        _gulp
+            .src(paths, { allowEmpty: true, base: rootDir.globPath })
+            .pipe(_gulp.dest(workingDir.absolutePath));
+
+    task.displayName = 'build-js';
+    task.description = 'Copy javascript files from source to build directory';
+
+    if (watch) {
+        const watchTask = () => _gulp.watch(paths, task);
+        watchTask.displayName = 'watch-build-js';
+        watchTask.description =
+            'Automatically copy javascript files to build directory on change';
+
+        return watchTask;
+    }
+    return task;
+};

--- a/src/task-builders/build/build-js-tests.js
+++ b/src/task-builders/build/build-js-tests.js
@@ -20,7 +20,7 @@ module.exports = (project, options) => {
     const rootDir = project.rootDir;
     const workingDir = rootDir.getChild('working');
 
-    const dirs = ['src', 'test'];
+    const dirs = ['test'];
     if (project.projectType === 'aws-microservice') {
         dirs.push('infra');
     }

--- a/src/task-builders/build/build-js-tests.js
+++ b/src/task-builders/build/build-js-tests.js
@@ -51,12 +51,12 @@ module.exports = (project, options) => {
             .src(paths, { allowEmpty: true, base: rootDir.globPath })
             .pipe(_gulp.dest(workingDir.absolutePath));
 
-    task.displayName = 'build-js';
+    task.displayName = 'build-js-tests';
     task.description = 'Copy javascript files from source to build directory';
 
     if (watch) {
         const watchTask = () => _gulp.watch(paths, task);
-        watchTask.displayName = 'watch-build-js';
+        watchTask.displayName = 'watch-build-js-tests';
         watchTask.description =
             'Automatically copy javascript files to build directory on change';
 

--- a/src/task-builders/build/build-ts-impl.js
+++ b/src/task-builders/build/build-ts-impl.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const _gulp = require('gulp');
+const _typescript = require('gulp-typescript');
+
+/**
+ * Sub builder that creates a task that will transpile typescript files into
+ * javascript files. This method will return a watcher if the watch option
+ * is set to true.
+ *
+ * @private
+ * @param {Object} project Reference to an object that contains project metadata
+ *        that can be used to customize build outputs.
+ * @param {Object} options An options object that can be used to customize the
+ *        task.
+ *
+ * @returns {Function} A gulp task.
+ */
+module.exports = (project, options) => {
+    const { watch } = Object.assign({ watch: false }, options);
+    const rootDir = project.rootDir;
+    const workingDir = rootDir.getChild('working');
+
+    const dirs = ['src'];
+    if (project.projectType === 'aws-microservice') {
+        dirs.push('infra');
+    }
+
+    const tsProject = _typescript.createProject('tsconfig.json');
+
+    const paths = dirs
+        .map((dir) => rootDir.getChild(dir))
+        .map((dir) => ['ts'].map((ext) => dir.getAllFilesGlob(ext)))
+        .reduce((result, arr) => result.concat(arr), []);
+
+    const distFiles = [
+        rootDir.getFileGlob('package-lock.json'),
+        rootDir.getFileGlob('Dockerfile*'),
+        rootDir.getFileGlob('LICENSE'),
+        rootDir.getFileGlob('README.md'),
+        rootDir.getFileGlob('.env'),
+        rootDir.getFileGlob(project.configFileName),
+    ];
+
+    const buildTask = () =>
+        _gulp
+            .src(paths, { base: rootDir.globPath })
+            .pipe(tsProject())
+            .pipe(_gulp.dest(workingDir.absolutePath));
+
+    const copyTask = () =>
+        _gulp
+            .src(distFiles, { allowEmpty: true })
+            .pipe(_gulp.dest(workingDir.absolutePath));
+
+    const task = _gulp.parallel([copyTask, buildTask]);
+
+    task.displayName = 'build-ts';
+    task.description = 'Build typescript source files to javascript files';
+
+    if (watch) {
+        const watchTask = () => _gulp.watch(paths, task);
+        watchTask.displayName = 'watch-build-ts';
+        watchTask.description =
+            'Automatically build typescript files on change';
+
+        return watchTask;
+    }
+    return task;
+};

--- a/src/task-builders/build/build-ts-impl.js
+++ b/src/task-builders/build/build-ts-impl.js
@@ -55,12 +55,12 @@ module.exports = (project, options) => {
 
     const task = _gulp.parallel([copyTask, buildTask]);
 
-    task.displayName = 'build-ts';
+    task.displayName = 'build-ts-impl';
     task.description = 'Build typescript source files to javascript files';
 
     if (watch) {
         const watchTask = () => _gulp.watch(paths, task);
-        watchTask.displayName = 'watch-build-ts';
+        watchTask.displayName = 'watch-build-ts-impl';
         watchTask.description =
             'Automatically build typescript files on change';
 

--- a/src/task-builders/build/build-ts-tests.js
+++ b/src/task-builders/build/build-ts-tests.js
@@ -21,7 +21,7 @@ module.exports = (project, options) => {
     const rootDir = project.rootDir;
     const workingDir = rootDir.getChild('working');
 
-    const dirs = ['src', 'test'];
+    const dirs = ['test'];
     if (project.projectType === 'aws-microservice') {
         dirs.push('infra');
     }

--- a/src/task-builders/build/build-ts-tests.js
+++ b/src/task-builders/build/build-ts-tests.js
@@ -55,12 +55,12 @@ module.exports = (project, options) => {
 
     const task = _gulp.parallel([copyTask, buildTask]);
 
-    task.displayName = 'build-ts';
+    task.displayName = 'build-ts-tests';
     task.description = 'Build typescript source files to javascript files';
 
     if (watch) {
         const watchTask = () => _gulp.watch(paths, task);
-        watchTask.displayName = 'watch-build-ts';
+        watchTask.displayName = 'watch-build-ts-tests';
         watchTask.description =
             'Automatically build typescript files on change';
 

--- a/src/task-builders/build/index.js
+++ b/src/task-builders/build/index.js
@@ -31,19 +31,29 @@ module.exports = (project, options) => {
     let tasks;
 
     if (project.projectType !== 'ui') {
-        const jsBuild = require('./build-js');
-        tasks = [jsBuild(project, options)];
+        const tasks = [];
+
+        const jsBuildImpl = require('./build-js-impl'); // build JS implementation (src folder)
+        tasks.push(jsBuildImpl(project, options));
+
+        // build tests
+        const jsBuildTests = require('./build-js-tests'); // build JS implementation (tests folder)
+        tasks.push(jsBuildTests(project, options));
 
         if (project.hasTypescript) {
-            const tsBuild = require('./build-ts');
-            tasks.push(tsBuild(project, options));
+            const tsBuildImpl = require('./build-ts-impl'); // build TS implementation (src folder)
+            tasks.push(tsBuildImpl(project, options));
+
+            const tsBuildTests = require('./build-ts-tests'); // build TS implementation (tests folder)
+            tasks.push(tsBuildTests(project, option));
+
         } else if (project.hasExportedTypes) {
             const typesBuild = require('./build-types');
             tasks.push(typesBuild(project, options));
         }
     } else {
         const tsBuild = require('./build-ui');
-        tasks = [tsBuild(project, options)];
+        tasks.push(tsBuild(project, options));
     }
 
     task = _gulp.parallel(tasks);

--- a/src/task-builders/build/index.js
+++ b/src/task-builders/build/index.js
@@ -28,10 +28,9 @@ module.exports = (project, options) => {
     }
 
     let task;
-    let tasks;
+    let tasks = [];
 
     if (project.projectType !== 'ui') {
-        const tasks = [];
 
         const jsBuildImpl = require('./build-js-impl'); // build JS implementation (src folder)
         tasks.push(jsBuildImpl(project, options));


### PR DESCRIPTION
## Summary
This PR adds feature support in v1.5.0 for building the source files and tests separately.

## Problem
This is necessary because of a circular dependency in the build system, such that the tests cannot be built until the implementation (src) is compiled and the implementation (src) cannot be built until the tests are compiled. This creates a scenario where the user must delete their tests in order to compile the source, then un-delete them once the source has compiled successfully.

## Solution

* Changed the `build-js` and `build-ts` task scripts to `build-js-impl` and `build-ts-impl` respectively, copied the script into two new scripts: `build-js-tests` and `build-ts-tests` which mirrors the implementation of the _impl_ build tasks.
* Aligned the `gulp build` default script to run _both_ the "impl" and "tests" scripts for both JS and TS (see index.js). This should maintain feature parity without breaking existing scripts.
* Bumped to 1.5.0 as a non-breaking feature addition
* Slight readability fixes in `gulp build` default script.

This will now enable us to modify our `Gulpfile` to add the tasks: `gulp build-src` and `gulp build-tests`
