### PR TITLE
Publish Composite Task Builder

### DIFF
--- a/src/task-builders/publish-container-task-builder.js
+++ b/src/task-builders/publish-container-task-builder.js
@@ -14,15 +14,12 @@ export class PublishContainerTaskBuilder extends TaskBuilder {
     /**
      * Creates a new task builder.
      *
-     * @param {String} [target='default'] The name of the CDK stack target
+     * @param {String} target The name of the CDK stack target
      * @param {String} [tag='latest'] An optional tag to apply to the container
      * image.
      */
-    constructor(target = 'default', tag = 'latest') {
-        if (
-            typeof target !== 'undefined' &&
-            (typeof target !== 'string' || target.length === 0)
-        ) {
+    constructor(target, tag = 'latest') {
+        if (typeof target !== 'string' || target.length === 0) {
             throw new Error('Invalid target (arg #1)');
         }
         if (
@@ -35,9 +32,7 @@ export class PublishContainerTaskBuilder extends TaskBuilder {
             // When specifying the container target, if it is not called default, this
             // will create a named task
             `publish-container${target === 'default' ? '' : '-' + target}`,
-            `Publish container image for ${target || 'default'}:${
-                tag || 'latest'
-            }`
+            `Publish container image for ${target}:${tag}`
         );
 
         this._target = target;

--- a/src/task-builders/publish-container-task-builder.js
+++ b/src/task-builders/publish-container-task-builder.js
@@ -13,12 +13,15 @@ export class PublishContainerTaskBuilder extends TaskBuilder {
     /**
      * Creates a new task builder.
      *
-     * @param {String} target The name of the CDK stack target
+     * @param {String} [target='default'] The name of the CDK stack target
      * @param {String} [tag='latest'] An optional tag to apply to the container
      * image.
      */
-    constructor(target, tag) {
-        if (typeof target !== 'string' || target.length === 0) {
+    constructor(target = 'default', tag = 'latest') {
+        if (
+            typeof target !== 'undefined' &&
+            (typeof target !== 'string' || target.length === 0)
+        ) {
             throw new Error('Invalid target (arg #1)');
         }
         if (
@@ -28,8 +31,12 @@ export class PublishContainerTaskBuilder extends TaskBuilder {
             throw new Error('Invalid tag (arg #2)');
         }
         super(
-            'publish-container',
-            `Publish container image for ${target}:${tag}`
+            // When specifying the container target, if it is not called default, this
+            // will create a named task
+            `publish-container${target === 'default' ? '' : '-' + target}`,
+            `Publish container image for ${target || 'default'}:${
+                tag || 'latest'
+            }`
         );
 
         this._target = target;

--- a/src/task-builders/publish-container-task-builder.js
+++ b/src/task-builders/publish-container-task-builder.js
@@ -4,7 +4,7 @@ import TaskBuilder from '../task-builder.js';
 import { Project } from '../project.js';
 import { execa as _execa } from 'execa';
 import _gulp from 'gulp';
-import { getSemverComponents } from '../../test/utils/task-builder-snippets.js';
+import { getSemverComponents } from '../utils/semver-utils.js';
 
 /**
  * Builder function that can be used to generate a gulp task to publish a CDK

--- a/src/task-builders/publish-task-builder.js
+++ b/src/task-builders/publish-task-builder.js
@@ -67,19 +67,19 @@ export class PublishTaskBuilder extends TaskBuilder {
         }
         // Type container
         else if (type === 'container') {
-            return [new PublishContainerTaskBuilder()];
+            return [new PublishContainerTaskBuilder('default')];
         }
         // Type cli
         else if (type === 'cli') {
             if (containerTargetList.length > 0) {
-                return [new PublishContainerTaskBuilder()];
+                return [new PublishContainerTaskBuilder('default')];
             } else {
                 return [new PublishNpmTaskBuilder()];
             }
         }
         // Type api
         else if (type === 'api') {
-            return [new PublishContainerTaskBuilder()];
+            return [new PublishContainerTaskBuilder('default')];
         }
         // Type undefined or not supported
         return [new NotSupportedTaskBuilder()];

--- a/src/task-builders/publish-task-builder.js
+++ b/src/task-builders/publish-task-builder.js
@@ -1,0 +1,87 @@
+'use strict';
+
+import _gulp from 'gulp';
+import TaskBuilder from '../task-builder.js';
+import { Project } from '../project.js';
+import { NotSupportedTaskBuilder } from './not-supported-task-builder.js';
+import { PublishAwsTaskBuilder } from './publish-aws-task-builder.js';
+import { PublishNpmTaskBuilder } from './publish-npm-task-builder.js';
+import { PublishContainerTaskBuilder } from './publish-container-task-builder.js';
+
+/**
+ * General purpose publishing task that configures sub tasks for publishing based
+ * on the project. When a project is an API or container and has multiple container
+ * targets, this task will publish the target named "default". When the project is
+ * a CLI and there is a "default" container defined, this task will publish that,
+ * if there is no container defined, it will publish using npm.
+ */
+export class PublishTaskBuilder extends TaskBuilder {
+    /**
+     * Creates a new task builder.
+     */
+    constructor() {
+        super('publish', `Publishes project to a repository`);
+    }
+
+    /**
+     * Generates a gulp task to publish a project.
+     *
+     * @protected
+     * @param {Object} project Reference to the project for which the task needs
+     * to be defined.
+     *
+     * @returns {Function} A gulp task.
+     */
+    _createTask(project) {
+        if (!(project instanceof Project)) {
+            throw new Error('Invalid project (arg #1)');
+        }
+
+        const builders = this._getSubBuilders(project).map((builder) =>
+            builder.buildTask(project)
+        );
+
+        const task = _gulp.series(builders);
+        return task;
+    }
+
+    /**
+     * Returns a list of sub builders based on the project type and language.
+     * @private
+     */
+    _getSubBuilders(project) {
+        const { type } = project;
+        const containerTargetList = project.getContainerTargets();
+
+        // Type lib
+        if (type === 'lib') {
+            return [new PublishNpmTaskBuilder()];
+        }
+        // Type aws-microservice
+        else if (type === 'aws-microservice') {
+            return [new PublishAwsTaskBuilder()];
+        }
+        // Type ui
+        else if (type === 'ui') {
+            return [new NotSupportedTaskBuilder()];
+        }
+        // Type container
+        else if (type === 'container') {
+            return [new PublishContainerTaskBuilder()];
+        }
+        // Type cli
+        else if (type === 'cli') {
+            if (containerTargetList.length > 0) {
+                return [new PublishContainerTaskBuilder()];
+            } else {
+                return [new PublishNpmTaskBuilder()];
+            }
+        }
+        // Type api
+        else if (type === 'api') {
+            return [new PublishContainerTaskBuilder()];
+        }
+        // Type undefined or not supported
+        return [new NotSupportedTaskBuilder()];
+    }
+}

--- a/src/utils/semver-utils.js
+++ b/src/utils/semver-utils.js
@@ -1,0 +1,28 @@
+import semver from 'semver';
+
+/**
+ * Checks if a given input tag is a valid semantic version, and returns an array
+ * of the four corresponding tags (ex. tag = '1.2.3' => ['1.2.3', '1.2', '1', 'latest']).
+ * If tag = '1.2' => ['1.2.0', '1.2', '1', 'latest'].
+ * If tag = '1' => ['1.0.0', '1.0', '1', 'latest'].
+ * If the tag is not a semantic version, such as 'latest' simply returns ['latest']
+ *
+ * @param {String} tag String input for tag name of docker image
+ */
+export function getSemverComponents(tag) {
+    const semTag = semver.coerce(tag);
+    if (!semver.valid(semTag)) {
+        return [tag];
+    }
+
+    const major = semver.major(semTag);
+    const minor = semver.minor(semTag);
+    const patch = semver.patch(semTag);
+
+    return [
+        `${major}.${minor}.${patch}`,
+        `${major}.${minor}`,
+        `${major}`,
+        'latest',
+    ];
+}

--- a/test/unit/task-builders/package-task-builder-spec.js
+++ b/test/unit/task-builders/package-task-builder-spec.js
@@ -53,7 +53,7 @@ describe('[PackageTaskBuilder]', () => {
     }
 
     function _getExpectedSubBuilders(project) {
-        const { type, language } = project;
+        const { type } = project;
 
         const containerTargetList = project.getContainerTargets();
 

--- a/test/unit/task-builders/publish-container-task-builder-spec.js
+++ b/test/unit/task-builders/publish-container-task-builder-spec.js
@@ -5,7 +5,7 @@ _chai.use(_sinonChai);
 import _path from 'path';
 import _camelcase from 'camelcase';
 
-import { stub, spy } from 'sinon';
+import { stub } from 'sinon';
 import _esmock from 'esmock';
 import { Project } from '../../../src/project.js';
 import {
@@ -18,10 +18,7 @@ import {
     createModuleImporter,
     createGulpMock,
 } from '../../utils/object-builder.js';
-import {
-    getSemverComponents,
-    injectBuilderInitTests,
-} from '../../utils/task-builder-snippets.js';
+import { injectBuilderInitTests } from '../../utils/task-builder-snippets.js';
 
 const specificContainerTarget = 'myBuildArm'; // This is a second build defined in object-builder.js
 
@@ -160,6 +157,13 @@ describe('[PublishContainerTaskBuilder]', () => {
             };
         }
 
+        const semverComponentsObj = {
+            latest: ['latest'],
+            1: ['1.0.0', '1.0', '1', 'latest'],
+            '1.0': ['1.0.0', '1.0', '1', 'latest'],
+            '1.0.0': ['1.0.0', '1.0', '1', 'latest'],
+        };
+
         getAllProjectOverrides().forEach(({ title, overrides }) => {
             ['latest', '1', '1.0', '1.0.0'].forEach((tag) => {
                 describe(`Verify task - publish to container registry - (${title})`, () => {
@@ -178,7 +182,7 @@ describe('[PublishContainerTaskBuilder]', () => {
 
                         expect(execaMock).to.not.have.been.called;
 
-                        const semverComponents = getSemverComponents(tag);
+                        const semverComponents = semverComponentsObj[tag];
                         semverComponents.forEach((semTag, index) => {
                             const task = gulpMock.series.args[0][0][index];
 
@@ -232,7 +236,7 @@ describe('[PublishContainerTaskBuilder]', () => {
 
                         expect(execaMock).to.not.have.been.called;
 
-                        const semverComponents = getSemverComponents(tag);
+                        const semverComponents = semverComponentsObj[tag];
                         semverComponents.forEach((semTag, index) => {
                             const task =
                                 gulpMock.series.args[0][0][

--- a/test/unit/task-builders/publish-container-task-builder-spec.js
+++ b/test/unit/task-builders/publish-container-task-builder-spec.js
@@ -183,6 +183,13 @@ describe('[PublishContainerTaskBuilder]', () => {
                         expect(execaMock).to.not.have.been.called;
 
                         const semverComponents = semverComponentsObj[tag];
+
+                        // The number of tasks should be double the semver components
+                        expect(gulpMock.series.args[0][0]).to.have.lengthOf(
+                            semverComponents.length * 2,
+                            'Number of tasks in gulp series is incorrect'
+                        );
+
                         semverComponents.forEach((semTag, index) => {
                             const task = gulpMock.series.args[0][0][index];
 
@@ -237,6 +244,13 @@ describe('[PublishContainerTaskBuilder]', () => {
                         expect(execaMock).to.not.have.been.called;
 
                         const semverComponents = semverComponentsObj[tag];
+
+                        // The number of tasks should be double the semver components
+                        expect(gulpMock.series.args[0][0]).to.have.lengthOf(
+                            semverComponents.length * 2,
+                            'Number of tasks in gulp series is incorrect'
+                        );
+
                         semverComponents.forEach((semTag, index) => {
                             const task =
                                 gulpMock.series.args[0][0][

--- a/test/unit/task-builders/publish-container-task-builder-spec.js
+++ b/test/unit/task-builders/publish-container-task-builder-spec.js
@@ -34,7 +34,7 @@ describe('[PublishContainerTaskBuilder]', () => {
     );
 
     describe('ctor() <target, tag>', () => {
-        makeOptional(getAllButString('')).forEach((target) => {
+        getAllButString('').forEach((target) => {
             it(`should throw an error if invoked without a valid target (value=${target})`, async () => {
                 const TaskBuilder = await _importModule();
                 const error = 'Invalid target (arg #1)';
@@ -43,21 +43,6 @@ describe('[PublishContainerTaskBuilder]', () => {
 
                 expect(wrapper).to.throw(error);
             });
-        });
-
-        it('should not throw an error if the target is undefined', async () => {
-            const TaskBuilder = await _importModule();
-            const wrapper = () => new TaskBuilder(undefined, undefined);
-
-            expect(wrapper).to.not.throw();
-        });
-
-        it('should not throw an error if the target is undefined with a valid tag', async () => {
-            const TaskBuilder = await _importModule();
-            const tag = 'myTag';
-            const wrapper = () => new TaskBuilder(undefined, tag);
-
-            expect(wrapper).to.not.throw();
         });
 
         makeOptional(getAllButString('')).forEach((tag) => {
@@ -73,16 +58,13 @@ describe('[PublishContainerTaskBuilder]', () => {
     });
 
     [undefined, '1.0.0'].forEach((tag) => {
-        // Can explicitly state 'default' when overriding target repo or leave undefined
-        ['default', undefined, specificContainerTarget].forEach((target) => {
+        ['default', specificContainerTarget].forEach((target) => {
             injectBuilderInitTests(
                 _importModule,
                 `publish-container${
-                    !target || target === 'default' ? '' : '-' + target // Specifying a non default container creates a named task
+                    target === 'default' ? '' : '-' + target // Specifying a non default container creates a named task
                 }`,
-                `Publish container image for ${target || 'default'}:${
-                    tag || 'latest'
-                }`,
+                `Publish container image for ${target}:${tag || 'latest'}`,
                 [target, tag]
             );
         });

--- a/test/unit/task-builders/publish-container-task-builder-spec.js
+++ b/test/unit/task-builders/publish-container-task-builder-spec.js
@@ -18,7 +18,10 @@ import {
     createModuleImporter,
     createGulpMock,
 } from '../../utils/object-builder.js';
-import { injectBuilderInitTests } from '../../utils/task-builder-snippets.js';
+import {
+    getSemverComponents,
+    injectBuilderInitTests,
+} from '../../utils/task-builder-snippets.js';
 
 const specificContainerTarget = 'myBuildArm'; // This is a second build defined in object-builder.js
 
@@ -52,7 +55,7 @@ describe('[PublishContainerTaskBuilder]', () => {
             expect(wrapper).to.not.throw();
         });
 
-        it('shoud not throw an error if the target is undefined with a valid tag', async () => {
+        it('should not throw an error if the target is undefined with a valid tag', async () => {
             const TaskBuilder = await _importModule();
             const tag = 'myTag';
             const wrapper = () => new TaskBuilder(undefined, tag);
@@ -161,112 +164,112 @@ describe('[PublishContainerTaskBuilder]', () => {
             ['latest', '1', '1.0', '1.0.0'].forEach((tag) => {
                 describe(`Verify task - publish to container registry - (${title})`, () => {
                     it(`should use the docker cli to tag the container image (tag=${tag})`, async () => {
-                        const target = 'containerTarget1';
-                        const buildDefinition = {
-                            repo: 'container-repo-1',
-                        };
+                        const target = 'default';
                         const {
                             execaModuleMock: { execa: execaMock },
                             gulpMock,
                         } = await _createTask(
                             {
                                 ...overrides,
-                                'buildMetadata.container': {
-                                    default: {
-                                        repo: 'my-repo',
-                                        buildFile: 'BuildFile-1',
-                                        buildArgs: {
-                                            arg1: 'value1',
-                                        },
-                                    },
-                                    [target]: buildDefinition,
-                                },
                             },
                             target,
                             tag
                         );
-                        const task = gulpMock.series.args[0][0][0];
-
-                        const dockerBin = 'docker';
-                        const expectedArgs = ['tag', `${target}:${tag}`];
 
                         expect(execaMock).to.not.have.been.called;
 
-                        task();
+                        const semverComponents = getSemverComponents(tag);
+                        semverComponents.forEach((semTag, index) => {
+                            const task = gulpMock.series.args[0][0][index];
 
-                        expect(execaMock).to.have.been.calledOnce;
+                            const dockerBin = 'docker';
+                            const expectedArgs = [
+                                'tag',
+                                target,
+                                `${target}:${semTag}`,
+                            ];
 
-                        expect(execaMock.args[0]).to.have.lengthOf(3);
+                            execaMock.reset();
 
-                        // First arg
-                        expect(execaMock.args[0][0]).to.equal(dockerBin);
+                            task();
 
-                        // Second arg
-                        expect(execaMock.args[0][1])
-                            .to.be.an('array')
-                            .and.to.have.length(expectedArgs.length);
-                        expectedArgs.forEach((arg, index) => {
-                            expect(execaMock.args[0][1][index]).to.equal(arg);
-                        });
+                            expect(execaMock).to.have.been.calledOnce;
 
-                        // Third arg
-                        expect(execaMock.args[0][2]).to.deep.equal({
-                            stdio: 'inherit',
+                            expect(execaMock.args[0]).to.have.lengthOf(3);
+
+                            // First arg
+                            expect(execaMock.args[0][0]).to.equal(dockerBin);
+
+                            // Second arg
+                            expect(execaMock.args[0][1])
+                                .to.be.an('array')
+                                .and.to.have.length(expectedArgs.length);
+                            expectedArgs.forEach((arg, index) => {
+                                expect(execaMock.args[0][1][index]).to.equal(
+                                    arg
+                                );
+                            });
+
+                            // Third arg
+                            expect(execaMock.args[0][2]).to.deep.equal({
+                                stdio: 'inherit',
+                            });
                         });
                     });
 
                     it(`should use the docker cli to publish the image to the cloud (tag=${tag})`, async () => {
-                        const target = 'containerTarget1';
-                        const buildDefinition = {
-                            repo: 'container-repo-1',
-                        };
+                        const target = 'default';
                         const {
                             execaModuleMock: { execa: execaMock },
                             gulpMock,
                         } = await _createTask(
                             {
                                 ...overrides,
-                                'buildMetadata.container': {
-                                    default: {
-                                        repo: 'my-repo',
-                                        buildFile: 'BuildFile-1',
-                                        buildArgs: {
-                                            arg1: 'value1',
-                                        },
-                                    },
-                                    [target]: buildDefinition,
-                                },
                             },
                             target,
                             tag
                         );
-                        const task = gulpMock.series.args[0][0][1];
-
-                        const dockerBin = 'docker';
-                        const expectedArgs = ['push', `${target}:${tag}`];
 
                         expect(execaMock).to.not.have.been.called;
 
-                        task();
+                        const semverComponents = getSemverComponents(tag);
+                        semverComponents.forEach((semTag, index) => {
+                            const task =
+                                gulpMock.series.args[0][0][
+                                    index + semverComponents.length
+                                ];
 
-                        expect(execaMock).to.have.been.calledOnce;
+                            const dockerBin = 'docker';
+                            const expectedArgs = [
+                                'push',
+                                `${target}:${semTag}`,
+                            ];
 
-                        expect(execaMock.args[0]).to.have.lengthOf(3);
+                            execaMock.reset();
 
-                        // First arg
-                        expect(execaMock.args[0][0]).to.equal(dockerBin);
+                            task();
 
-                        // Second arg
-                        expect(execaMock.args[0][1])
-                            .to.be.an('array')
-                            .and.to.have.length(expectedArgs.length);
-                        expectedArgs.forEach((arg, index) => {
-                            expect(execaMock.args[0][1][index]).to.equal(arg);
-                        });
+                            expect(execaMock).to.have.been.calledOnce;
 
-                        // Third arg
-                        expect(execaMock.args[0][2]).to.deep.equal({
-                            stdio: 'inherit',
+                            expect(execaMock.args[0]).to.have.lengthOf(3);
+
+                            // First arg
+                            expect(execaMock.args[0][0]).to.equal(dockerBin);
+
+                            // Second arg
+                            expect(execaMock.args[0][1])
+                                .to.be.an('array')
+                                .and.to.have.length(expectedArgs.length);
+                            expectedArgs.forEach((arg, index) => {
+                                expect(execaMock.args[0][1][index]).to.equal(
+                                    arg
+                                );
+                            });
+
+                            // Third arg
+                            expect(execaMock.args[0][2]).to.deep.equal({
+                                stdio: 'inherit',
+                            });
                         });
                     });
                 });

--- a/test/unit/task-builders/publish-task-builder-spec.js
+++ b/test/unit/task-builders/publish-task-builder-spec.js
@@ -71,19 +71,19 @@ describe('[PublishTaskBuilder]', () => {
         }
         // Type container
         else if (type === 'container') {
-            return [{ name: 'publish-container', ctorArgs: [] }];
+            return [{ name: 'publish-container', ctorArgs: ['default'] }];
         }
         // Type cli
         else if (type === 'cli') {
             if (containerTargetList.length > 0) {
-                return [{ name: 'publish-container', ctorArgs: [] }];
+                return [{ name: 'publish-container', ctorArgs: ['default'] }];
             } else {
                 return [{ name: 'publish-npm', ctorArgs: [] }];
             }
         }
         // Type api
         else if (type === 'api') {
-            return [{ name: 'publish-container', ctorArgs: [] }];
+            return [{ name: 'publish-container', ctorArgs: ['default'] }];
         }
         // Type undefined or not supported
         return [{ name: 'not-supported', ctorArgs: [] }];

--- a/test/unit/task-builders/publish-task-builder-spec.js
+++ b/test/unit/task-builders/publish-task-builder-spec.js
@@ -1,0 +1,100 @@
+import _chai from 'chai';
+import _sinonChai from 'sinon-chai';
+_chai.use(_sinonChai);
+
+import _path from 'path';
+
+import _esmock from 'esmock';
+import {
+    createGulpMock,
+    createModuleImporter,
+    createTaskBuilderImportDefinitions,
+    createTaskBuilderImportMocks,
+} from '../../utils/object-builder.js';
+import {
+    injectBuilderInitTests,
+    injectSubBuilderCompositionTests,
+} from '../../utils/task-builder-snippets.js';
+
+describe('[PublishTaskBuilder]', () => {
+    const _subBuilders = [
+        'publish-npm',
+        'publish-aws',
+        'publish-container',
+        'not-supported',
+    ];
+    const _importDefinitions = createTaskBuilderImportDefinitions(_subBuilders);
+    const _importModule = createModuleImporter(
+        'src/task-builders/publish-task-builder.js',
+        {
+            taskBuilderMock: 'src/task-builder.js',
+            gulpMock: 'gulp',
+            ..._importDefinitions,
+        },
+        'PublishTaskBuilder'
+    );
+
+    async function _initializeTask() {
+        const gulpMock = createGulpMock();
+        const { mocks, mockReferences } =
+            createTaskBuilderImportMocks(_subBuilders);
+
+        const TaskBuilder = await _importModule({
+            gulpMock,
+            ...mockReferences,
+        });
+        const builder = new TaskBuilder();
+
+        return {
+            builder,
+            gulpMock,
+            subBuilderMocks: mocks,
+        };
+    }
+
+    function _getExpectedSubBuilders(project) {
+        const { type } = project;
+
+        const containerTargetList = project.getContainerTargets();
+
+        // Type lib
+        if (type === 'lib') {
+            return [{ name: 'publish-npm', ctorArgs: [] }];
+        }
+        // Type aws-microservice
+        else if (type === 'aws-microservice') {
+            return [{ name: 'publish-aws', ctorArgs: [] }];
+        }
+        // Type ui
+        else if (type === 'ui') {
+            return [{ name: 'not-supported', ctorArgs: [] }];
+        }
+        // Type container
+        else if (type === 'container') {
+            return [{ name: 'publish-container', ctorArgs: [] }];
+        }
+        // Type cli
+        else if (type === 'cli') {
+            if (containerTargetList.length > 0) {
+                return [{ name: 'publish-container', ctorArgs: [] }];
+            } else {
+                return [{ name: 'publish-npm', ctorArgs: [] }];
+            }
+        }
+        // Type api
+        else if (type === 'api') {
+            return [{ name: 'publish-container', ctorArgs: [] }];
+        }
+        // Type undefined or not supported
+        return [{ name: 'not-supported', ctorArgs: [] }];
+    }
+
+    injectBuilderInitTests(
+        _importModule,
+        'publish',
+        `Publishes project to a repository`
+    );
+
+    // Generalized composition tests
+    injectSubBuilderCompositionTests(_initializeTask, _getExpectedSubBuilders);
+});

--- a/test/utils/task-builder-snippets.js
+++ b/test/utils/task-builder-snippets.js
@@ -3,6 +3,7 @@ import _sinonChai from 'sinon-chai';
 _chai.use(_sinonChai);
 
 import { spy } from 'sinon';
+import semver from 'semver';
 import {
     buildProjectDefinition,
     createCtorNotCalledChecker,
@@ -171,4 +172,31 @@ export function injectSubBuilderCompositionTests(
             });
         });
     });
+}
+
+/**
+ * Checks if a given input tag is a valid semantic version, and returns an array
+ * of the four corresponding tags (ex. tag = '1.2.3' => ['1.2.3', '1.2', '1', 'latest']).
+ * If tag = '1.2' => ['1.2.0', '1.2', '1', 'latest'].
+ * If tag = '1' => ['1.0.0', '1.0', '1', 'latest'].
+ * If the tag is not a semantic version, such as 'latest' simply returns ['latest']
+ *
+ * @param {String} tag String input for tag name of docker image
+ */
+export function getSemverComponents(tag) {
+    const semTag = semver.coerce(tag);
+    if (!semver.valid(semTag)) {
+        return [tag];
+    }
+
+    const major = semver.major(semTag);
+    const minor = semver.minor(semTag);
+    const patch = semver.patch(semTag);
+
+    return [
+        `${major}.${minor}.${patch}`,
+        `${major}.${minor}`,
+        `${major}`,
+        'latest',
+    ];
 }

--- a/test/utils/task-builder-snippets.js
+++ b/test/utils/task-builder-snippets.js
@@ -3,7 +3,6 @@ import _sinonChai from 'sinon-chai';
 _chai.use(_sinonChai);
 
 import { spy } from 'sinon';
-import semver from 'semver';
 import {
     buildProjectDefinition,
     createCtorNotCalledChecker,
@@ -172,31 +171,4 @@ export function injectSubBuilderCompositionTests(
             });
         });
     });
-}
-
-/**
- * Checks if a given input tag is a valid semantic version, and returns an array
- * of the four corresponding tags (ex. tag = '1.2.3' => ['1.2.3', '1.2', '1', 'latest']).
- * If tag = '1.2' => ['1.2.0', '1.2', '1', 'latest'].
- * If tag = '1' => ['1.0.0', '1.0', '1', 'latest'].
- * If the tag is not a semantic version, such as 'latest' simply returns ['latest']
- *
- * @param {String} tag String input for tag name of docker image
- */
-export function getSemverComponents(tag) {
-    const semTag = semver.coerce(tag);
-    if (!semver.valid(semTag)) {
-        return [tag];
-    }
-
-    const major = semver.major(semTag);
-    const minor = semver.minor(semTag);
-    const patch = semver.patch(semTag);
-
-    return [
-        `${major}.${minor}.${patch}`,
-        `${major}.${minor}`,
-        `${major}`,
-        'latest',
-    ];
 }


### PR DESCRIPTION
- Created composite publish-task-builder.js to configure sub tasks for publishing based on project type and corresponding test file.
- Updated publish-container-task-builder.js to create multiple docker tag and push commands for semantic versioning such that if tag param = '1.0.0', this will tag and push ['1.0.0', '1.0', '1', 'latest']. Updated test file to reflect this change and test that all tasks are being configured correctly.
- Added semver-utils.js function.