### PR TITLE
Copy static directories into working directory

### DIFF
--- a/src/project.js
+++ b/src/project.js
@@ -105,7 +105,7 @@ export class Project {
             {},
         );
 
-        this._rootDir = Directory.createTree('./', {
+        const rootDir = {
             src: null,
             test: {
                 unit: null,
@@ -132,7 +132,14 @@ export class Project {
             '.tscache': null,
             logs: null,
             'cdk.out': null,
-        });
+        };
+
+        for (const dir of this._staticDirs) {
+            rootDir[dir] = null;
+            rootDir.working[dir] = null;
+        }
+
+        this._rootDir = Directory.createTree('./', rootDir);
         this._banner = `${_colors.cyan(this._name)}@${_colors.green(
             this._version,
         )} (${_colors.blue(this._type)} - ${_colors.yellow(this._language)})`;

--- a/src/project.js
+++ b/src/project.js
@@ -45,6 +45,7 @@ export class Project {
                 type,
                 language,
                 requiredEnv,
+                staticDirs,
                 staticFilePatterns,
                 aws,
                 container,
@@ -75,6 +76,7 @@ export class Project {
         this._type = type;
         this._language = language;
         this._staticFilePatterns = staticFilePatterns || [];
+        this._staticDirs = staticDirs || [];
         this._requiredEnv = requiredEnv || [];
         this._aws = aws || { stacks: {} };
         this._cdkTargets = Object.keys(this._aws.stacks).reduce(
@@ -235,6 +237,16 @@ export class Project {
      */
     getStaticFilePatterns() {
         return this._staticFilePatterns.concat([]);
+    }
+
+    /**
+     * Returns a list of static file directories configured for the project.
+     *
+     * @returns {Array} An array of strings used to identify static files
+     * included in the build.
+     */
+    getStaticDirs() {
+        return this._staticDirs.concat([]);
     }
 
     /**

--- a/src/schema/project-definition.js
+++ b/src/schema/project-definition.js
@@ -158,6 +158,12 @@ export default {
                  * process without any compilation/modification.
                  */
                 staticFilePatterns: { type: 'array' },
+
+                /**
+                 * Any static directories that should be copied over during the build
+                 * process without any compilation/modification.
+                 */
+                staticDirs: { type: 'array' },
             },
             required: ['type', 'language'],
         },

--- a/src/task-builders/copy-files-task-builder.js
+++ b/src/task-builders/copy-files-task-builder.js
@@ -36,7 +36,7 @@ export class CopyFilesTaskBuilder extends TaskBuilder {
         }
 
         const { rootDir } = project;
-        const dirs = ['src', 'test', 'scripts'].concat(project.getStaticDirs());
+        const dirs = ['src', 'test', 'scripts'];
         const extensions = ['json'].concat(project.getStaticFilePatterns());
         const containerBuildFiles = project
             .getContainerTargets()
@@ -69,9 +69,16 @@ export class CopyFilesTaskBuilder extends TaskBuilder {
             .reduce((result, arr) => result.concat(arr), [])
             .concat(extras.map((item) => rootDir.getFileGlob(item)));
 
+        const staticPaths = project.getStaticDirs()
+            .map((dir) => rootDir.getChild(dir))
+            .filter((dir) => dir.exists())
+            .map(dir => dir._absolutePath + '**');
+
+        const finalPaths = paths.concat(staticPaths);
+
         const task = () =>
             _gulp
-                .src(paths, {
+                .src(finalPaths, {
                     allowEmpty: true,
                     base: rootDir.globPath,
                 })

--- a/src/task-builders/copy-files-task-builder.js
+++ b/src/task-builders/copy-files-task-builder.js
@@ -72,7 +72,7 @@ export class CopyFilesTaskBuilder extends TaskBuilder {
         const staticPaths = project.getStaticDirs()
             .map((dir) => rootDir.getChild(dir))
             .filter((dir) => dir.exists())
-            .map(dir => dir._absolutePath + '**');
+            .map(dir =>  dir.getAllFilesGlob());
 
         const finalPaths = paths.concat(staticPaths);
 

--- a/src/task-builders/copy-files-task-builder.js
+++ b/src/task-builders/copy-files-task-builder.js
@@ -36,7 +36,7 @@ export class CopyFilesTaskBuilder extends TaskBuilder {
         }
 
         const { rootDir } = project;
-        const dirs = ['src', 'test', 'scripts'];
+        const dirs = ['src', 'test', 'scripts'].concat(project.getStaticDirs());
         const extensions = ['json'].concat(project.getStaticFilePatterns());
         const containerBuildFiles = project
             .getContainerTargets()

--- a/test/unit/project-spec.js
+++ b/test/unit/project-spec.js
@@ -623,6 +623,41 @@ describe('[Project]', function () {
         });
     });
 
+    describe('getDirs()', function () {
+        it('should return an empty array if the definition does not contain static file patterns', function () {
+            const definition = buildProjectDefinition({
+                'buildMetadata.staticDirs': undefined,
+            });
+            const project = new Project(definition);
+
+            expect(project.getStaticDirs()).to.deep.equal([]);
+        });
+
+        it('should return the values specified in the project definition', function () {
+            const values = ['foo-dir', 'bar-dir'];
+            const definition = buildProjectDefinition({
+                'buildMetadata.staticDirs': values,
+            });
+            const project = new Project(definition);
+
+            expect(project.getStaticDirs()).to.deep.equal(values);
+        });
+
+        it('should return a copy of the values, not a reference', function () {
+            const values = ['foo-dir', 'bar-dir'];
+            const definition = buildProjectDefinition({
+                'buildMetadata.staticDirs': values,
+            });
+            const project = new Project(definition);
+
+            const oldValues = project.getStaticDirs();
+            oldValues.pop();
+
+            const newValues = project.getStaticDirs();
+            expect(newValues).to.not.equal(oldValues);
+        });
+    });
+
     describe('getStaticFilePatterns()', function () {
         it('should return an empty array if the definition does not contain static file patterns', function () {
             const definition = buildProjectDefinition({

--- a/test/unit/task-builders/copy-files-task-builder-spec.js
+++ b/test/unit/task-builders/copy-files-task-builder-spec.js
@@ -93,10 +93,6 @@ describe('[CopyFilesTaskBuilder]', function () {
             return generateGlobPatterns(rootDir, dirs, extensions).concat(
                 extras.map((file) => _path.join(rootDir, file)),
             );
-
-            // foo.concat([rootDir + '/foo-dir/**/*', rootDir +'/bar-dir/**/*'])
-
-            return foo;
         }
 
         // List of all projects - they can all run without containers


### PR DESCRIPTION
Any directories specified in the `staticDirs` field in package.json will be copied into the working directory

`staticDirs` should be an array of relative paths. Example:

```json
{    
    "buildMetadata": {
        "type": "cli",
        "language": "ts",
        "staticDirs": ["test-dir"],
        "container": {
            "default": {
                "repo": "copy-dirs-repo",
                "buildFile": "Dockerfile",
                "buildArgs": {
                    "ARCH_SUFFIX": "x86",
                    "CONFIG_FILE_NAME": ".env"
                },
                "buildSecrets": {
                    "npmSecret": {
                        "type": "file",
                        "src": ".npmrc"
                    }
                }
            }
        }
    }
}
```